### PR TITLE
fix: Added snapshot policy variables

### DIFF
--- a/src/06_elastic_resources_common/01_snapshot.tf
+++ b/src/06_elastic_resources_common/01_snapshot.tf
@@ -27,6 +27,6 @@ resource "elasticstack_elasticsearch_snapshot_lifecycle" "default_snapshot_polic
   include_global_state = true
 
   expire_after = var.snapshot_lifecycle_default.expire_after
-  min_count    = 5
-  max_count    = 50
+  min_count    = var.snapshot_lifecycle_default.min_count
+  max_count    = var.snapshot_lifecycle_default.max_count
 }

--- a/src/06_elastic_resources_common/99_variables.tf
+++ b/src/06_elastic_resources_common/99_variables.tf
@@ -32,9 +32,13 @@ variable "snapshot_lifecycle_default" {
   description = "(Required) Identifier for the default snapshot lifecycle policy of the EC deployment."
   type = object({
     expire_after = string
+    min_count    = optional(number, 5)
+    max_count    = optional(number, 50)
   })
   default = {
     expire_after = "30d"
+    min_count    = 5
+    max_count    = 50
   }
 }
 

--- a/src/06_elastic_resources_common/README.md
+++ b/src/06_elastic_resources_common/README.md
@@ -92,7 +92,7 @@ You can check them in this PR:
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | n/a | yes |
 | <a name="input_role_mappings"></a> [role\_mappings](#input\_role\_mappings) | n/a | `map(any)` | `{}` | no |
-| <a name="input_snapshot_lifecycle_default"></a> [snapshot\_lifecycle\_default](#input\_snapshot\_lifecycle\_default) | (Required) Identifier for the default snapshot lifecycle policy of the EC deployment. | <pre>object({<br/>    expire_after = string<br/>  })</pre> | <pre>{<br/>  "expire_after": "30d"<br/>}</pre> | no |
+| <a name="input_snapshot_lifecycle_default"></a> [snapshot\_lifecycle\_default](#input\_snapshot\_lifecycle\_default) | (Required) Identifier for the default snapshot lifecycle policy of the EC deployment. | <pre>object({<br/>    expire_after = string<br/>    min_count    = optional(number, 5)<br/>    max_count    = optional(number, 50)<br/>  })</pre> | <pre>{<br/>  "expire_after": "30d",<br/>  "max_count": 50,<br/>  "min_count": 5<br/>}</pre> | no |
 
 ## Outputs
 

--- a/src/06_elastic_resources_common/env/pagopa-prod/terraform.tfvars
+++ b/src/06_elastic_resources_common/env/pagopa-prod/terraform.tfvars
@@ -18,6 +18,8 @@ default_snapshot_policy = {
 
 snapshot_lifecycle_default = {
   expire_after = "90d"
+  min_count    = 5
+  max_count    = 100
 }
 
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### New application definition checklist

Checklist based on the documentation provided [here](https://github.com/pagopa/elasticcloud-infra/blob/main/src/07_elastic_resources_app/products/README.md) 


- [ ] Created a new application folder
- [ ] Defined `appSettings.json`
- [ ] Defined the index lifecycle management policy for your app 
- [ ] If using elastic agent: defined your service name in `08_elastic_resources_integration/env/<target>-<env>/terraform.tfvars` => `k8s_application_log_instance_names` variable

For any detail refer to the documentation linked above

### Apply in your environment

Once finished with your pr, you can apply the changes in your environment by running the appropriate pipeline in the correct order:
the order is determined by the folder name, both on the project and the pipeline folder structure

**[Here is the link to the pipelines](https://dev.azure.com/pagopaspa/paymon-iac/_build?view=folders)**



### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
